### PR TITLE
fix undefined options and user-defined uploadpath

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var knox = require('knox');
 var gutil = require('gulp-util');
 
 module.exports = function (aws, options) {
+  options = options || {};
+  
   if (!options.delay) { options.delay = 0; }
 
   var client = knox.createClient(aws);
@@ -15,7 +17,7 @@ module.exports = function (aws, options) {
       var isFile = fs.lstatSync(file.path).isFile();
       if (!isFile) { return false; }
 
-      var uploadPath = file.path.replace(file.base, '');
+      var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       var headers = { 'x-amz-acl': 'public-read' };
 
       setTimeout(function() {


### PR DESCRIPTION
Allow users to upload to a specific subdirectory by exposing an `uploadPath` option.

Also this contains a minor bugfix in case the options argument is not passed.
