### PR TITLE
Support for gzipped pipeflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Then, use it in your `gulpfile.js`:
 var s3 = require("gulp-s3");
 
 aws = JSON.parse(fs.readFileSync('./aws.json'));
-options = { delay: 1000 } // optional delay each request by x milliseconds
-gulp.src('./dist/**', {read: false})
-    .pipe(s3(aws, options));
+gulp.src('./dist/**')
+    .pipe(s3(aws));
 ```
 
 ## API
@@ -61,7 +60,6 @@ var options = { gzippedOnly: true };
 
 gulp.src('./dist/**')
 .pipe(gzip())
-.pipe(gulp.dest('./dist'))
 .pipe(s3(aws, options));
 
 });


### PR DESCRIPTION
Using the gulp-gzipped plugin, pipe contents can be gzipped before being uploaded to s3.  To have s3 serve the gzipped content correctly headers must be set.

Purpose:
1) Change knox.putFile to knox.putBuffer to support piping gzipped es
2) Added gzipped option which does suffix removal, content-type stuff
3) Documentation
