### PR TITLE
Tweaked the filename regex to allow any length extension (>2) 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = function (aws, options) {
 
   var client = knox.createClient(aws);
   var waitTime = 0;
-  var regexGzip = /\.([a-z]{2,4})\.gz$/i;
-  var regexGeneral = /\.([a-z]{2,4})$/i;
+  var regexGzip = /\.([a-z]{2,})\.gz$/i;
+  var regexGeneral = /\.([a-z]{2,})$/i;
 
   return es.mapSync(function (file) {
 


### PR DESCRIPTION
Previous limit of 2-4 chars for file extensions excluded ones like .appcache
