### PR TITLE
Limit number of concurrent uploads via async.eachLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Headers to set to each file uploaded to S3
 
 ```javascript
 var options = { headers: {'Cache-Control': 'max-age=315360000, no-transform, public'} }
-gulp.src('./dist/**', {read: false})
+gulp.src('./dist/**')
     .pipe(s3(aws, options));
 ```
 
@@ -63,6 +63,32 @@ gulp.src('./dist/**')
 .pipe(s3(aws, options));
 
 });
+```
+
+#### options.uploadPath
+
+Type: `String`
+Default: `''`
+
+S3 prefix to add to each uploaded file.
+
+```javascript
+var options = { uploadPath: '/dev/assets/' }
+gulp.src('./dist/**')
+    .pipe(s3(aws, options));
+```
+
+#### options.asyncLimit
+
+Type: `Number`
+Default: `4`
+
+Limits the number of concurrent uploads to S3.
+
+```javascript
+var options = { asyncLimit: 8 }
+gulp.src('./dist/**')
+    .pipe(s3(aws, options));
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var es = require('event-stream');
 var knox = require('knox');
 var gutil = require('gulp-util');
 var mime = require('mime');
+var async = require('async');
 mime.default_type = 'text/plain';
 
 module.exports = function (aws, options) {
@@ -12,14 +13,20 @@ module.exports = function (aws, options) {
   if (!options.delay) { options.delay = 0; }
 
   var client = knox.createClient(aws);
-  var waitTime = 0;
   var regexGzip = /\.([a-z]{2,})\.gz$/i;
   var regexGeneral = /\.([a-z]{2,})$/i;
+  var files = [];
 
-  return es.mapSync(function (file) {
+  return es.through(function write (data) {
+    files.push(data);
+  }, function end () {
+    var self = this;
 
+    async.eachLimit(files, options.asyncLimit || 4, function (file, cb) {
       // Verify this is a file
-      if (!file.isBuffer()) { return file; }
+      if (!file.isBuffer()) { return cb(); }
+
+      gutil.log(gutil.colors.blue('[INFO]', 'handling ' + file.path));
 
       var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
@@ -36,7 +43,7 @@ module.exports = function (aws, options) {
           uploadPath = uploadPath.substring(0, uploadPath.length - 3);
       } else if (options.gzippedOnly) {
           // Ignore non-gzipped files
-          return file;
+          return cb();
       }
 
       // Set content type based of file extension
@@ -51,13 +58,17 @@ module.exports = function (aws, options) {
 
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
-          gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+          gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath + " (" + (res && res.statusCode) + ")" + " (" + err + ")"));
+          cb(err);
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
           res.resume();
+          self.emit('data', file);
+          cb(null);
         }
       });
-
-      return file;
+    }, function (err) {
+      self.emit('end', err);
+    });
   });
 };

--- a/index.js
+++ b/index.js
@@ -26,8 +26,6 @@ module.exports = function (aws, options) {
       // Verify this is a file
       if (!file.isBuffer()) { return cb(); }
 
-      gutil.log(gutil.colors.blue('[INFO]', 'handling ' + file.path));
-
       var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
       var headers = { 'x-amz-acl': 'public-read' };


### PR DESCRIPTION
Limiting the number of concurrent uploads makes gulp-s3 much more robust in practice.  I kept running into issues where either locally or remotely things would error out because gulp-s3 was creating the upload requests for all files back to back without capping the max number of concurrent uploads.
