### PR TITLE
Stat object on file buffer doesn't appear to work anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ module.exports = function (aws, options) {
         }
       }
 
-      headers['Content-Length'] = file.stat.size;
+		headers['Content-Length'] = file.contents.toString().length;
+
 
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function (aws, options) {
 
       headers['Content-Length'] = file.contents.toString().length;
 
-
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (aws, options) {
         }
       }
 
-		headers['Content-Length'] = file.contents.toString().length;
+      headers['Content-Length'] = file.contents.toString().length;
 
 
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {


### PR DESCRIPTION
Really handy tool. Thanks for building it.

I'm getting failures with node _v0.10.20_. There doesn't appear to be a _stat_ object attached to the file [buffer](http://nodejs.org/api/buffer.html) on line 50. I'm guessing it was dropped in a more recent version of node???

Anyway... hope this is a sane fix.

Thanks
Jamie
