### PR TITLE
Fixed an EditorConfig error and removed indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = tabs
+indent_style = tab
 indent_size = 2
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
tabs should instead be tab.

If using tabs, specifying indent size in your EditorConfig file is not recommended.  There's no need to specify the size of indentation (since your contributors may have different preferences than you do).  While we allow indent size specification in EditorConfig files, it's usually only useful for projects with mixed tabs and spaces (yes there are projects which do that on purpose).
