### PR TITLE
Task is finished after all files are uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (aws, options) {
   var regexGzip = /\.([a-z]{2,})\.gz$/i;
   var regexGeneral = /\.([a-z]{2,})$/i;
 
-  return es.mapSync(function (file) {
+  return es.map(function (file, callback) {
 
       // Verify this is a file
       if (!file.isBuffer()) { return file; }
@@ -52,12 +52,12 @@ module.exports = function (aws, options) {
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+          callback(err, res);
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
           res.resume();
+          callback(null, file);
         }
       });
-
-      return file;
   });
 };


### PR DESCRIPTION
Hi,

first of all, thanks for the plugin!

My gulpfile needs to know when the upload is finished, and I think that should be the default behaviour. The current version finishes the task as soon as all files are scheduled.

Jan
