### PR TITLE
Corrected docs for S3 headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ gulp.src('./dist/**')
 
 #### options.headers
 
-Type: `Array`          
-Default: `[]`
+Type: `Object`          
+Default: `{}`
 
 Headers to set to each file uploaded to S3
 
 ```javascript
-var options = { headers: {'Cache-Control': 'max-age=315360000, no-transform, public'} }
+var options = { 
+  headers: {
+    'Cache-Control': 'max-age=315360000, no-transform, public',
+    'x-amz-acl': 'private'
+  } 
+};
 gulp.src('./dist/**', {read: false})
     .pipe(s3(aws, options));
 ```


### PR DESCRIPTION
 `options.headers` actually accepts on Object, not an array. I expanded the example to use 2 headers to make it clear.
