### PR TITLE
Add numeric digits to regex, for .mp4

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (aws, options) {
   var client = knox.createClient(aws);
   var waitTime = 0;
   var regexGzip = /\.([a-z]{2,})\.gz$/i;
-  var regexGeneral = /\.([a-z]{2,})$/i;
+  var regexGeneral = /\.([a-z0-9]{2,})$/i;
 
   return es.mapSync(function (file) {
 


### PR DESCRIPTION
Currently, the `regexGeneral` doesn't match `.mp4` files, so they are uploaded with the `binary/octet-stream` `Content-Type`. This fixes that.
