### PR TITLE
Adding retries option

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,20 +6,38 @@ var gutil = require('gulp-util');
 var mime = require('mime');
 mime.default_type = 'text/plain';
 
+var TIMEOUT = 5 * 60 * 1000;
+var RETRY_TIMEOUT = 30 * 1000;
+
 module.exports = function (aws, options) {
   options = options || {};
 
-  if (!options.delay) { options.delay = 0; }
-
   var client = knox.createClient(aws);
-  var waitTime = 0;
   var regexGzip = /\.([a-z]{2,})\.gz$/i;
   var regexGeneral = /\.([a-z]{2,})$/i;
 
-  return es.mapSync(function (file) {
-
+  return es.map(function (file, callback) {
       // Verify this is a file
-      if (!file.isBuffer()) { return file; }
+      if (!file.isBuffer()) {
+        return callback(null);
+      }
+      var timeout;
+      var filePathDisplay = file.path.split(process.cwd())[1];
+
+      function cb (obj) {
+        if (obj === null) {
+          clearTimeout(timeout);
+        }
+        callback(obj);
+      }
+
+      function bigError() {
+        cb(new Error('gulp-s3 has failed on file ' + filePathDisplay));
+      }
+
+      function createTimeout() {
+        timeout = setTimeout(bigError, TIMEOUT);
+      }
 
       var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
@@ -36,7 +54,7 @@ module.exports = function (aws, options) {
           uploadPath = uploadPath.substring(0, uploadPath.length - 3);
       } else if (options.gzippedOnly) {
           // Ignore non-gzipped files
-          return file;
+          return callback(null);
       }
 
       // Set content type based of file extension
@@ -51,24 +69,49 @@ module.exports = function (aws, options) {
 
       var retries = 0;
 
-      function doPut (err, res) {
-        if (err || res.statusCode !== 200) {
-          gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
-          gutil.log(gutil.colors.yellow('[RETRYING]', file.path + " -> " + uploadPath));
-          if (options.retries && retries < options.retries) {
-            retries++;
-            client.putBuffer(file.contents, uploadPath, headers, doPut);
-          } else {
-            gutil.log(gutil.colors.pink('[MAX RETRIES]', file.path + " -> " + uploadPath));
-          }
+      var retryTimeout;
+
+      function doPut() {
+        clearTimeout(retryTimeout);
+        if (uploadSuccess) {
+          return;
+        }
+        retryTimeout = setTimeout(doPut, RETRY_TIMEOUT);
+        createTimeout();
+        client.putBuffer(file.contents, uploadPath, headers, onPut);
+      }
+
+      function retry() {
+        clearTimeout(retryTimeout);
+        if (options.retries && retries < options.retries) {
+          retries++;
+          gutil.log(gutil.colors.yellow('[RETRYING ' + retries + ']', filePathDisplay));
+          doPut();
         } else {
-          gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
-          res.resume();
+          gutil.log(gutil.colors.red('[MAX RETRIES]', filePathDisplay));
+          bigError();
         }
       }
 
-      client.putBuffer(file.contents, uploadPath, headers, doPut);
+      var uploadSuccess = false;
 
-      return file;
+      function onPut (err, res) {
+        clearTimeout(timeout);
+        if (err || res.statusCode !== 200) {
+          gutil.log(gutil.colors.red('[FAILED]', filePathDisplay));
+          retry();
+        } else {
+          if (!uploadSuccess) {
+            clearTimeout(retryTimeout);
+            gutil.log(gutil.colors.green('[SUCESS]', filePathDisplay));
+            res.resume();
+            cb(null);
+          }
+          uploadSuccess = true;
+        }
+      }
+
+      gutil.log(gutil.colors.blue('[UPLOADING]', filePathDisplay));
+      doPut();
   });
 };

--- a/index.js
+++ b/index.js
@@ -48,15 +48,15 @@ module.exports = function (aws, options) {
       }
 
       headers['Content-Length'] = file.stat.size;
-      
+
       var retries = 0;
 
       function doPut (err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
           gutil.log(gutil.colors.yellow('[RETRYING]', file.path + " -> " + uploadPath));
-          if (options.retries && i < options.retries) {
-            i++;
+          if (options.retries && retries < options.retries) {
+            retries++;
             client.putBuffer(file.contents, uploadPath, headers, doPut);
           } else {
             gutil.log(gutil.colors.pink('[MAX RETRIES]', file.path + " -> " + uploadPath));

--- a/index.js
+++ b/index.js
@@ -48,15 +48,26 @@ module.exports = function (aws, options) {
       }
 
       headers['Content-Length'] = file.stat.size;
+      
+      var retries = 0;
 
-      client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
+      function doPut (err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+          gutil.log(gutil.colors.yellow('[RETRYING]', file.path + " -> " + uploadPath));
+          if (options.retries && i < options.retries) {
+            i++;
+            client.putBuffer(file.contents, uploadPath, headers, doPut);
+          } else {
+            gutil.log(gutil.colors.pink('[MAX RETRIES]', file.path + " -> " + uploadPath));
+          }
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
           res.resume();
         }
-      });
+      }
+
+      client.putBuffer(file.contents, uploadPath, headers, doPut);
 
       return file;
   });

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "async": "",
-    "event-stream": "*",
-    "gulp-util": "~2.2.6",
-    "knox": "",
-    "mime": "~1.2.11"
+    "event-stream": "3.0.5",
+    "gulp-util": "2.2.6",
+    "knox": "0.9.2",
+    "mime": "1.2.11"
   },
   "devDependencies": {
     "mocha": "~1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "gulp-s3",
-  "version": "0.3.0",
+  "version": "0.3.0-loggi",
   "description": "A plugin for Gulp that uploads files to s3",
   "keywords": [
     "gulpplugin",
     "gulp",
     "s3"
   ],
-  "homepage": "https://github.com/nkostelnik/gulp-s3",
-  "bugs": "https://github.com/nkostelnik/gulp-s3/issues",
+  "homepage": "https://github.com/loggi/gulp-s3/",
+  "bugs": "https://github.com/loggi/gulp-s3//issues",
   "author": {
     "name": "Nicholas Kostelnik",
     "email": "",
@@ -17,7 +17,7 @@
   "main": "./index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nkostelnik/gulp-s3.git"
+    "url": "git://github.com/loggi/gulp-s3.git"
   },
   "scripts": {
     "test": "mocha"
@@ -40,7 +40,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/nkostelnik/gulp-s3/blob/master/LICENSE"
+      "url": "https://github.com/loggi/gulp-s3/blob/master/LICENSE"
     }
   ]
 }


### PR DESCRIPTION
Hello! First of all i wish to thank you guys for the great project.

Sometimes, when you got any problem with your network, and your upload fails, you can't retry it.
So I added the `retries` option that allows you to set how many times you wish gulp-s3 will retry to send your file.

``` JavaScript
var s3 = require("gulp-s3");
var aws = {
  "key": "AKIAI3Z7CUAFHG53DMJA",
  "secret": "acYxWRu5RRa6CwzQuhdXEfTpbQA+1XQJ7Z1bGTCx",
  "bucket": "dev.example.com",
  "region": "eu-west-1"
};
var options = {
  headers: {
    'Cache-Control': 'max-age=315360000, no-transform, public'
  },
  retries: 3
};
gulp.src('./dist/**')
    .pipe(s3(aws, options));
```
