### PR TITLE
Optionally die on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,12 @@ module.exports = function (aws, options) {
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
-          if (options.dieOnError) { process.exit.bind(process, 1); }
+          if (options.dieOnError) {
+            gutil.log("exiting with status -1");
+            process.exit.bind(process, -1);
+          } else {
+            gutil.log("continuing to publish...");
+          }
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
           res.resume();

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = function (aws, options) {
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+          if (options.dieOnError) { process.exit.bind(process, 1); }
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
           res.resume();

--- a/index.js
+++ b/index.js
@@ -53,10 +53,8 @@ module.exports = function (aws, options) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
           if (options.dieOnError) {
-            gutil.log(gutil.colors.red("exiting with status -1"));
-            process.exit.bind(process, -1);
-          } else {
-            gutil.log(gutil.colors.green("continuing to publish..."));
+            gutil.log("exiting with status 1");
+            process.exit(1);
           }
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));

--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ module.exports = function (aws, options) {
         if (err || res.statusCode !== 200) {
           gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
           if (options.dieOnError) {
-            gutil.log("exiting with status -1");
+            gutil.log(gutil.colors.red("exiting with status -1"));
             process.exit.bind(process, -1);
           } else {
-            gutil.log("continuing to publish...");
+            gutil.log(gutil.colors.green("continuing to publish..."));
           }
         } else {
           gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));


### PR DESCRIPTION
If the `dieOnError` option is set, exit with status 1 if an error occurs. 

See https://github.com/nkostelnik/gulp-s3/issues/47
