### PR TITLE
null reference with error and no response

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,13 @@ module.exports = function (aws, options) {
     headers['Content-Length'] = contentLength;
 
     client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
-      if (err || res.statusCode !== 200) {
+      if (err) {
+        gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+        gutil.log(gutil.colors.red('  AWS ERROR:', err));
+        finished(err, null)
+      } else if(res && res.statusCode !== 200){
         gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
         gutil.log(gutil.colors.red('  HTTP STATUS:', res.statusCode));
-        gutil.log(gutil.colors.red('  AWS ERROR:', err));
         finished(err, null)
       } else {
         gutil.log(gutil.colors.green('[SUCCESS]') + ' ' + gutil.colors.grey(file.path) + gutil.colors.green(" -> ") + uploadPath);


### PR DESCRIPTION
I was running into a scenario where the response object was null and I had one error. The problem was that the response log was being printed before the error's one. So I had the process crashing before I realized what the problem was. 

```
[FAILED] /dist/404.html -> /recife/404.html
//node_modules/gulp-s3/index.js:59
        gutil.log(gutil.colors.red('  HTTP STATUS:', res.statusCode));
                                                        ^

TypeError: Cannot read property 'statusCode' of undefined
   ...
```

I separated the log messages in two different conditions, so one problem won't fall into another.