### PR TITLE
Update README with corrected usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Set the remote folder on the S3 bucket
 
 ```javascript
 var options = { uploadPath: 'remote-folder' } // It will upload the 'src' into '/remote-folder'
-gulp.src('./dist/**', {read: false})
+gulp.src('./dist/**')
     .pipe(s3(AWS, options));
 ```
 
@@ -57,7 +57,7 @@ var options = {
     'x-amz-acl': 'private'
   } 
 };
-gulp.src('./dist/**', {read: false})
+gulp.src('./dist/**')
     .pipe(s3(AWS, options));
 ```
 


### PR DESCRIPTION
Remove `{ read: false }` on `gulp.src()`s since that causes the plugin silently fail.