### PR TITLE
Replace deprecated dependency 'gulp-util'

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 var es = require('event-stream');
 var knox = require('knox');
-var gutil = require('gulp-util');
+var flog = require('fancy-log');
+var colors = require('ansi-colors');
 var mime = require('mime');
 mime.default_type = 'text/plain';
 
@@ -19,7 +20,7 @@ module.exports = function (aws, options) {
 
     var uploadPath = file.path.replace(file.base, options.uploadPath || '');
     uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
-    
+
     var headers = { 'x-amz-acl': 'public-read' };
 
     if (options.headers) {
@@ -55,21 +56,21 @@ module.exports = function (aws, options) {
 
     client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
       if (err || res && res.statusCode !== 200) {
-        gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+        flog(colors.red('[FAILED]', file.path + " -> " + uploadPath));
 
         if (err) {
-          gutil.log(gutil.colors.red('  AWS ERROR:', err));
+          flog(colors.red('  AWS ERROR:', err));
           throw new Error(err);
-        } 
-        
+        }
+
         if (res && res.statusCode !== 200){
-          gutil.log(gutil.colors.red('  HTTP STATUS:', res.statusCode));
+          flog(colors.red('  HTTP STATUS:', res.statusCode));
           throw new Error('HTTP Status Code: ' + res.statusCode);
         }
 
         finished(err, null)
       } else {
-        gutil.log(gutil.colors.green('[SUCCESS]') + ' ' + gutil.colors.grey(file.path) + gutil.colors.green(" -> ") + uploadPath);
+        flog(colors.green('[SUCCESS]') + ' ' + colors.grey(file.path) + colors.green(" -> ") + uploadPath);
         res.resume();
         finished(null, file)
       }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "test": "mocha"
   },
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "async": "",
     "event-stream": "*",
-    "gulp-util": "~2.2.6",
+    "fancy-log": "^1.3.3",
     "knox": "",
     "mime": "~1.2.11"
   },

--- a/test/main.js
+++ b/test/main.js
@@ -6,7 +6,8 @@ should = require('should'),
 path = require('path');
 require('mocha');
 
-var gutil = require('gulp-util'),
-s3 = require('../');
+var flog = require('fancy-log');
+var colors = require('ansi-colors');
+var s3 = require('../');
 
 describe('gulp-s3', function () { });


### PR DESCRIPTION
`gulp-util` was deprecated by it's author, some replacements are suggested in the [repo](https://github.com/gulpjs/gulp-util)